### PR TITLE
Removed duplicated line on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Options
 - changelog: Initialize a changelog file
 - emd: Initialize a README emd file
 - git: Initialize a git repository
-- golang: Initialize a golang project
 ```
 
 ## Cli examples


### PR DESCRIPTION
Removed duplicated line "- golang: Initialize a golang project" on the sample output of the -l flag